### PR TITLE
Bids-api [main] Add code for bids API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,9 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'factory_bot_rails', '~> 6.2'
   gem 'rspec-rails', '~> 5.1'
+  gem 'rspec-activemodel-mocks', '~> 1.1'
+  gem 'shoulda-callback-matchers', '~> 1.1'
+  gem 'shoulda-matchers', '~> 5.3'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,10 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rspec-activemodel-mocks (1.1.0)
+      activemodel (>= 3.0)
+      activesupport (>= 3.0)
+      rspec-mocks (>= 2.99, < 4.0)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
     rspec-expectations (3.11.0)
@@ -172,6 +176,10 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.11.0)
+    shoulda-callback-matchers (1.1.4)
+      activesupport (>= 3)
+    shoulda-matchers (5.3.0)
+      activesupport (>= 5.2.0)
     sqlite3 (1.4.2)
     strscan (3.0.1)
     thor (1.2.1)
@@ -184,6 +192,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux-musl
 
@@ -194,7 +203,10 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   puma (~> 5.6.2)
   rails (~> 7.0.2)
+  rspec-activemodel-mocks (~> 1.1)
   rspec-rails (~> 5.1)
+  shoulda-callback-matchers (~> 1.1)
+  shoulda-matchers (~> 5.3)
   sqlite3 (~> 1.4)
   tzinfo-data
 

--- a/app/controllers/bids_controller.rb
+++ b/app/controllers/bids_controller.rb
@@ -1,0 +1,47 @@
+class BidsController < ApplicationController
+
+  def index
+    countries = params[:countries]&.split(',') || []
+    categories = params[:categories]&.split(',') || []
+    channels = params[:channels]&.split(',') || []
+
+    combinations = countries.product(categories).product(channels).map(&:flatten)
+
+    bids = []
+
+    if combinations.present?
+      combinations.each do |combination|
+        country, category, channel = combination[0], combination[1], combination[2]
+
+        country_bids = country_bids(country)
+        category_bids = category_bids(country_bids, category)
+        bid = category_bids.find_by(channel: channel) || category_bids.find_by(channel: '*') || country_bids.find_by(category: '*', channel: '*')
+
+        bid = default_bid unless bid
+
+        bids << { 'country': country, 'category': category, channel: channel, 'amount': bid.amount } if bid
+      end
+    end
+
+    render json: { bids: bids }, status: :ok
+  end
+
+  private
+
+  def country_bids(country)
+    country_bids = Bid.where(country: country)
+    country_bids = Bid.where(country: '*') if country_bids.blank?
+    country_bids
+  end
+
+  def category_bids(country_bids, category)
+    category_bids = country_bids.where(category: category)
+    category_bids = country_bids.where(category: '*') if category_bids.blank?
+    category_bids
+  end
+
+  def default_bid
+    @default_bid ||= Bid.find_by(country: '*', category: '*', channel: '*')
+  end
+
+end

--- a/app/controllers/bids_controller.rb
+++ b/app/controllers/bids_controller.rb
@@ -4,9 +4,7 @@ class BidsController < ApplicationController
     countries = params[:countries]&.split(',') || []
     categories = params[:categories]&.split(',') || []
     channels = params[:channels]&.split(',') || []
-
     combinations = countries.product(categories).product(channels).map(&:flatten)
-
     bids = []
 
     if combinations.present?
@@ -17,7 +15,7 @@ class BidsController < ApplicationController
         category_bids = category_bids(country_bids, category)
         bid = category_bids.find_by(channel: channel) || category_bids.find_by(channel: '*') || country_bids.find_by(category: '*', channel: '*')
 
-        bid = default_bid unless bid
+        bid = Bid.default.first unless bid
 
         bids << { 'country': country, 'category': category, channel: channel, 'amount': bid.amount } if bid
       end
@@ -38,10 +36,6 @@ class BidsController < ApplicationController
     category_bids = country_bids.where(category: category)
     category_bids = country_bids.where(category: '*') if category_bids.blank?
     category_bids
-  end
-
-  def default_bid
-    @default_bid ||= Bid.find_by(country: '*', category: '*', channel: '*')
   end
 
 end

--- a/app/models/bid.rb
+++ b/app/models/bid.rb
@@ -5,6 +5,9 @@ class Bid < ApplicationRecord
   # Callbacks
   before_save :set_defaults
 
+  # Scopes
+  scope :default, -> { where(country: '*', category: '*', channel: '*') }
+
   # Validations
   validates :amount, presence: true
   validates :amount, numericality: { greater_than: 0 }, allow_blank: true

--- a/app/models/bid.rb
+++ b/app/models/bid.rb
@@ -1,4 +1,22 @@
 # frozen_string_literal: true
 
 class Bid < ApplicationRecord
+
+  # Callbacks
+  before_save :set_defaults
+
+  # Validations
+  validates :amount, presence: true
+  validates :amount, numericality: { greater_than: 0 }, allow_blank: true
+
+  private
+
+  def set_defaults
+    default_attributes = [:category, :country, :channel]
+
+    default_attributes.each do |attribute|
+      self[attribute] = '*' if self[attribute].nil?
+    end
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+
+  resources :bids, only: :index
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,23 +2,22 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[6.1].define(version: 2021_06_08_100421) do
-
+ActiveRecord::Schema[7.0].define(version: 2021_06_08_100421) do
   create_table "bids", force: :cascade do |t|
     t.string "country"
     t.string "category"
     t.string "channel"
     t.decimal "amount"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/spec/models/bid_spec.rb
+++ b/spec/models/bid_spec.rb
@@ -6,6 +6,35 @@ RSpec.describe Bid, type: :model do
 
   describe 'Validations' do
     it { is_expected.to validate_presence_of(:amount) }
+    it { is_expected.to validate_numericality_of(:amount).is_greater_than(0) }
   end
 
+  describe 'Callbacks' do
+    it { is_expected.to callback(:set_defaults).before(:save) }
+  end
+
+  describe 'Scopes' do
+    let!(:bid) { create(:bid) }
+    let!(:default_bid) { create(:bid, country: '*', category: '*', channel: '*') }
+
+    context '.default' do
+      it { expect(Bid.default).to include(default_bid) }
+      it { expect(Bid.default).not_to include(bid) }
+    end
+  end
+
+  describe 'Instance Methods' do
+
+    describe '#set_defaults' do
+      let(:bid) { create(:bid, country: nil) }
+
+      before do
+        bid.send(:set_defaults)
+      end
+
+      it 'set all default columns to default' do
+        expect(bid.country).not_to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/bid_spec.rb
+++ b/spec/models/bid_spec.rb
@@ -3,5 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Bid, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of(:amount) }
+  end
+
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,8 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+require 'rspec/active_model/mocks'
+require 'shoulda/matchers'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -43,7 +45,6 @@ RSpec.configure do |config|
 
   # Include factory-bot methods
   config.include FactoryBot::Syntax::Methods
-
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 
@@ -66,4 +67,18 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    # Choose a test framework:
+    with.test_framework :rspec
+
+    # Choose one or more libraries:
+    # with.library :active_record
+    # with.library :active_model
+    # with.library :action_controller
+    # Or, choose the following (which implies all of the above):
+    with.library :rails
+  end
 end

--- a/spec/requests/bids_spec.rb
+++ b/spec/requests/bids_spec.rb
@@ -32,3 +32,25 @@ describe 'Minimum Bids' do
     end
   end
 end
+
+describe 'Only one default bid present' do
+  describe 'GET /bids' do
+    before do
+      create(:bid, country: '*', category: '*', channel: '*', amount: 1.0)
+    end
+
+    it 'returns the same amount for all bid combinations' do
+      get '/bids', params: { countries: 'us', categories: 'finance', channels: 'ca,ga' }
+
+      expect(response).to have_http_status(:ok)
+
+      bids_response = response.parsed_body['bids']
+      expect(bids_response).to match_array(
+        [
+          { 'country' => 'us', 'category' => 'finance', 'channel' => 'ca', 'amount' => '1.0' },
+          { 'country' => 'us', 'category' => 'finance', 'channel' => 'ga', 'amount' => '1.0' }
+        ]
+      )
+    end
+  end
+end

--- a/spec/requests/bids_spec.rb
+++ b/spec/requests/bids_spec.rb
@@ -33,7 +33,7 @@ describe 'Minimum Bids' do
   end
 end
 
-describe 'Only one default bid present' do
+describe 'Only one default bid is present' do
   describe 'GET /bids' do
     before do
       create(:bid, country: '*', category: '*', channel: '*', amount: 1.0)
@@ -51,6 +51,49 @@ describe 'Only one default bid present' do
           { 'country' => 'us', 'category' => 'finance', 'channel' => 'ga', 'amount' => '1.0' }
         ]
       )
+    end
+  end
+end
+
+describe 'Only one bid is present' do
+  describe 'GET /bids' do
+    before do
+      create(:bid, country: 'us', category: 'finance', channel: 'ca', amount: 1.0)
+    end
+
+    it 'returns the correct amount for the stored combination' do
+      get '/bids', params: { countries: 'us', categories: 'finance', channels: 'ca' }
+
+      expect(response).to have_http_status(:ok)
+
+      bids_response = response.parsed_body['bids']
+      expect(bids_response).to match_array(
+        [
+          { 'country' => 'us', 'category' => 'finance', 'channel' => 'ca', 'amount' => '1.0' },
+        ]
+      )
+    end
+
+    it 'returns no bids for the wrong combination' do
+      get '/bids', params: { countries: 'us', categories: 'finance', channels: 'ga' }
+
+      expect(response).to have_http_status(:ok)
+
+      bids_response = response.parsed_body['bids']
+      expect(bids_response).to match_array([])
+    end
+  end
+end
+
+describe 'No bids are present' do
+  describe 'GET /bids' do
+    it 'returns no bids for the wrong combination' do
+      get '/bids', params: { countries: 'us', categories: 'finance', channels: 'ga' }
+
+      expect(response).to have_http_status(:ok)
+
+      bids_response = response.parsed_body['bids']
+      expect(bids_response).to match_array([])
     end
   end
 end


### PR DESCRIPTION
In this PR, we have added the following features:

- API endpoint for getting bids for combinations
- Validations on bids model
- Tests on bids model and controller

**Approach:** We try to find out the bid with the combination otherwise we switch to the default values. If not found, we return an empty response.

<img width="862" alt="Screenshot 2022-12-26 at 1 34 41 AM" src="https://user-images.githubusercontent.com/41813980/209480710-fbcd12ab-f736-4e39-899c-0cf2dbabcc16.png">

